### PR TITLE
Set specific memory for merge task if specified

### DIFF
--- a/src/python/WMCore/WMSpec/WMTask.py
+++ b/src/python/WMCore/WMSpec/WMTask.py
@@ -596,7 +596,7 @@ class WMTaskHelper(TreeHelper):
 
         return splittingParams
 
-    def setJobResourceInformation(self, timePerEvent=None, sizePerEvent=None, memoryReq=None):
+    def setJobResourceInformation(self, timePerEvent=None, sizePerEvent=None, memoryReq=None, taskType=None):
         """
         _setJobResourceInformation_
 
@@ -604,7 +604,11 @@ class WMTaskHelper(TreeHelper):
         the three key values are main memory usage, time per processing unit (e.g. time per event) and
         disk usage per processing unit (e.g. size per event).
         """
-        if self.taskType() in ["Merge", "Cleanup", "LogCollect"]:
+
+        # If task type is specified, it may be that we dont want "Merge" tasks to be ignored, 
+        # or that the task type is not one of the three to ignore
+
+        if self.taskType() in ["Merge", "Cleanup", "LogCollect"] and taskType is None:
             # don't touch job requirements for these task types
             return
 
@@ -1215,14 +1219,17 @@ class WMTaskHelper(TreeHelper):
             self.monitoring.section_("PerformanceMonitor")
         return
 
-    def setMaxPSS(self, maxPSS):
+    def setMaxPSS(self, maxPSS, taskType=None):
         """
         _setMaxPSS_
 
         Set MaxPSS performance monitoring for this task.
         :param maxPSS: maximum Proportional Set Size (PSS) memory consumption in MiB
         """
-        if self.taskType() in ["Merge", "Cleanup", "LogCollect"]:
+        # If task type is specified, it may be that we dont want "Merge" tasks to be ignored, 
+        # or that the task type is not one of the three to ignore
+        
+        if self.taskType() in ["Merge", "Cleanup", "LogCollect"] and taskType is None:
             # keep the default settings (from StdBase) for these task types
             return
 

--- a/src/python/WMCore/WMSpec/WMWorkload.py
+++ b/src/python/WMCore/WMSpec/WMWorkload.py
@@ -893,9 +893,13 @@ class WMWorkloadHelper(PersistencyHelper):
 
         for task in taskIterator:
             if isinstance(memory, dict):
-                mem = memory.get(task.name())
+                if task.name() in memory:
+                    mem = memory.get(task.name())
+                else:
+                    mem = memory.get("default")
             else:
                 mem = memory
+            
             task.setJobResourceInformation(memoryReq=mem)
             self.setMemory(memory, task)
 


### PR DESCRIPTION
This fix uses the feature of defining 'memory' as a dictionary with task names. If a task name is in the given dictionary, it should set that task to the corresponding memory value. Otherwise, it should use a 'default' value given in the dictionary.

This PR also modifies the functions that actually set the memory:

* [setJobResourceInformation](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/WMTask.py#L599)

* [setMaxPSS](https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/WMSpec/WMTask.py#L1218)

This way, if a task is type "Merge" and is also specified, it should not be ignored. 